### PR TITLE
Fix broken links in default urlprefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Arguments:
    - `replyAnonymously` (when disabled requires logging in in order to publish)
    - `hideContent` (when disabled it shows the content if the anchor is a naddr)
  - `urls`: comma-separated pairs of URLs
-   - defaults to `naddr:nostr.com/,npub:nostr.com/,nprofile:nostr.com/,nevent:nostr.com/,note:nostr.com/,tag:snort.social/t/`
+   - defaults to `naddr:njump.me/,npub:njump.me/,nprofile:njump.me/,nevent:njump.me/,note:njump.me/,tag:snort.social/t/`
    - `https://` will be automatically prepended
 
 ```html

--- a/src/util/ui.test.ts
+++ b/src/util/ui.test.ts
@@ -11,7 +11,7 @@ describe("ui utils", () => {
       profiles: () => [],
       rootEventIds: [],
       disableFeatures: [],
-      urlPrefixes: parseUrlPrefixes('naddr:nostr.com/,')
+      urlPrefixes: parseUrlPrefixes('naddr:habla.news/a/,')
     });
 
     it('links naddr with title if mentioned', () => {
@@ -29,7 +29,7 @@ describe("ui utils", () => {
       };
 
       let result = parseContent(eventToNoteEvent(e), store);
-      expect(result).toEqual('<p>awesome article\n <a href="https://nostr.com/naddr1qqxnzd3cxqmrzv3exgmr2wfeqyf8wumn8ghj7ur4wfcxcetsv9njuetnqyxhwumn8ghj7mn0wvhxcmmvqy08wumn8ghj7mn0wd68yttjv4kxz7fwdehkkmm5v9ex7tnrdakszynhwden5te0danxvcmgv95kutnsw43qz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpzpmhxue69uhkummnw3ezuamfdejsygrwg6zz9hahfftnsup23q3mnv5pdz46hpj4l2ktdpfu6rhpthhwjvpsgqqqw4rskylmpy">@naddr1qq...lmpy</a></p>');
+      expect(result).toEqual('<p>awesome article\n <a href="https://habla.news/a/naddr1qqxnzd3cxqmrzv3exgmr2wfeqyf8wumn8ghj7ur4wfcxcetsv9njuetnqyxhwumn8ghj7mn0wvhxcmmvqy08wumn8ghj7mn0wd68yttjv4kxz7fwdehkkmm5v9ex7tnrdakszynhwden5te0danxvcmgv95kutnsw43qz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpzpmhxue69uhkummnw3ezuamfdejsygrwg6zz9hahfftnsup23q3mnv5pdz46hpj4l2ktdpfu6rhpthhwjvpsgqqqw4rskylmpy">@naddr1qq...lmpy</a></p>');
     });
 
     it('parses a nostr url with a custom url prefix', () => {
@@ -41,7 +41,7 @@ describe("ui utils", () => {
         "content": "nostr:naddr1qqxnzd3cxqmrzv3exgmr2wfeqyf8wumn8ghj7ur4wfcxcetsv9njuetnqyxhwumn8ghj7mn0wvhxcmmvqy08wumn8ghj7mn0wd68yttjv4kxz7fwdehkkmm5v9ex7tnrdakszynhwden5te0danxvcmgv95kutnsw43qz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpzpmhxue69uhkummnw3ezuamfdejsygrwg6zz9hahfftnsup23q3mnv5pdz46hpj4l2ktdpfu6rhpthhwjvpsgqqqw4rskylmpy"
       };
       let result = parseContent(eventToNoteEvent(e), store);
-      expect(result).toMatch('<p><a href="https://nostr.com/naddr1qqxnzd3cxqmrzv');
+      expect(result).toMatch('<p><a href="https://habla.news/a/naddr1qqxnzd3cxqmrzv');
 
       e.content = 'I love #Bitcoin';
       e.tags = [['t', 'Bitcoin']];

--- a/src/util/ui.ts
+++ b/src/util/ui.ts
@@ -213,11 +213,11 @@ export const generateTags = (content: string): string[][] => {
 
 export const parseUrlPrefixes = (value: string = '') => {
   const result: { [key in UrlPrefixesKeys]?: string; } = {
-    naddr: 'https://nostr.com/',
-    npub: 'https://nostr.com/',
-    nprofile: 'https://nostr.com/',
-    nevent: 'https://nostr.com/',
-    note: 'https://nostr.com/',
+    naddr: 'https://njump.me/',
+    npub: 'https://njump.me/',
+    nprofile: 'https://njump.me/',
+    nevent: 'https://njump.me/',
+    note: 'https://njump.me/',
     tag: 'https://snort.social/t/'
   };
 


### PR DESCRIPTION
When clicking "..." and then "event data" in comments, links are broken because nostr.com doesn't resolve nostr n-addresses anymore. I replaced nostr.com with njump.me that correctly handles the different types of event data.